### PR TITLE
Merging back in try/catch around removeObserver from main SVGKit project

### DIFF
--- a/Source/QuartzCore additions/SVGKLayer.m
+++ b/Source/QuartzCore additions/SVGKLayer.m
@@ -67,7 +67,13 @@
 
 - (void)dealloc
 {
-	[self removeObserver:self forKeyPath:@"showBorder"];
+	//FIXME: Apple crashes on this line, even though BY DEFINITION Apple should not be crashing: [self removeObserver:self forKeyPath:@"showBorder"];
+	@try {
+		[self removeObserver:self forKeyPath:@"showBorder"];
+	}
+	@catch (NSException *exception) {
+		DDLogError(@"Exception removing showBorder observer");
+	}
 	
 	self.SVGImage = nil;
 }


### PR DESCRIPTION
Merging back in try/catch around removeObserver that's similarly in main SVGKit (see https://github.com/SVGKit/SVGKit/blob/2.x/Source/QuartzCore%20additions/SVGKLayer.m#L60-L66 ) . This is a workaround to an exception that gets thrown:
`"Cannot remove an observer <SVGKLayer 0x608000a68a00> for the key path "showBorder" from <SVGKLayer 0x608000a68a00> because it is not registered as an observer"`
upon calling removeObserver, even though the init always adds the observer.

I'm trying to investigate this a bit further, but for now the try/catch seems to help avoid an exception from causing a total crash.

Right now I seem to observe this when using SVGKLayer (on it's own, without use of SVKLayeredImage) . I'm still trying to understand why, but I don't observe the issue if I set the layer's action dictionary to a dict of [NSNull null] objects:

    NSMutableDictionary *layerActions = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                       [NSNull null], @"onOrderIn",
                                       [NSNull null], @"onOrderOut",
                                       [NSNull null], @"sublayers",
                                       [NSNull null], @"contents",
                                       [NSNull null], @"bounds",
                                       [NSNull null], @"position",
                                       [NSNull null], @"hidden",
                                       [NSNull null], @"transform",
                                       nil]; 

of course this effectively disables animation support, so isn't a great workaround.



